### PR TITLE
Add daisyui plugin to Tailwind config

### DIFF
--- a/SGAL-frontend/tailwind.config.js
+++ b/SGAL-frontend/tailwind.config.js
@@ -7,5 +7,6 @@ module.exports = {
   theme: {
     extend: {},
   },
+  plugins: [require('daisyui')]
 
 }


### PR DESCRIPTION
## Summary
- configure Tailwind to use DaisyUI plugin

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fe274c6248324870235c13be4cc1c